### PR TITLE
[CHORE] Make type optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ snap-*.tar
 
 # Contains Dialyzer PLTs
 /priv
+
+# Intellij idea
+.idea/*
+*.iml

--- a/lib/snap/responses/hit.ex
+++ b/lib/snap/responses/hit.ex
@@ -32,7 +32,7 @@ defmodule Snap.Hit do
 
   @type t :: %__MODULE__{
           index: String.t(),
-          type: String.t(),
+          type: String.t() | nil,
           id: String.t(),
           score: float() | nil,
           source: map() | nil,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Snap.MixProject do
 
   @original_github_url "https://github.com/breakroom/snap"
   @github_url "https://github.com/surgeventures/snap"
-  @version "0.10.2"
+  @version "0.10.3"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Snap.MixProject do
 
   @original_github_url "https://github.com/breakroom/snap"
   @github_url "https://github.com/surgeventures/snap"
-  @version "0.10.3"
+  @version "0.10.4"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Snap.MixProject do
 
   @original_github_url "https://github.com/breakroom/snap"
   @github_url "https://github.com/surgeventures/snap"
-  @version "0.10.4"
+  @version "0.10.5"
 
   def project do
     [


### PR DESCRIPTION
Type field was marked as deprecated in Elastic 6.0.0: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html.

It was removed in version 8 and now causing problem with Hammox mocking in Elixir. Hence we're make it optional for compatibility.